### PR TITLE
Share Rubocop configuration as a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+*.gem
+*.rbc
+/.config
+/.yardoc/
+/_yardoc/
+/coverage/
+/doc/
+/rdoc/
+/InstalledFiles
+/pkg/
+/tmp/
+
+## Environment normalization:
+.ruby-gemset
+.ruby-version
+/.bundle/
+/lib/bundler/man/
+/vendor/bundle
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: default.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the style guide will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
+but please note that the style guide does **not** follow [SemVer](https://semver.org).
+
+## [Unreleased]
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Removed
+
+-
+
+### Security
+
+-
+
+## [v1]
+
+### Added
+
+- Migrate style guides from developers manual to gem
+
+### Removed
+
+- `Naming/MemoizedInstanceVariableName` (project-specific)
+
+[Unreleased]: https://github.com/InspireNL/Manoflex/compare/v1...HEAD
+[v1]: https://github.com/InspireNL/Manoflex/tree/v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in inspire-ruby-style.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+PATH
+  remote: .
+  specs:
+    inspire-ruby-style (1.0.0)
+      rubocop (~> 0.58)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    jaro_winkler (1.5.1)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    unicode-display_width (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  inspire-ruby-style!
+  rake (~> 10.0)
+
+BUNDLED WITH
+   1.16.1

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Inspire Innovation BV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# inspire-ruby-style
+# Inspire's Ruby Style
+
+This gem packages [Inspire]'s [Rubocop] configuration so that it can easily be
+used in multiple projects. Projects can inherit the global configuration, and
+easily add or overwrite rules as necessary.
+
+The gem additionally declares Rubocop as a dependency. Since different versions
+of Rubocop have different default rules, it is important to run the same version
+in all projects to achieve the same Ruby style. Nonetheless, projects can opt-in
+to newer Rubocop versions by adding Rubocop as a dependency in their `Gemfile`
+with the newer version. 
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem "inspire-ruby-style", github: "inspirenl/inspire-ruby-style", tag: "v1"
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install inspire-ruby-style
+
+## Usage
+
+After installing the gem, create a `.rubocop.yml` file in the project root with
+the following contents:
+
+```yaml
+inherit_gem:
+  inspire-ruby-style:
+    - default.yml
+```
+
+Individual rules can be overwritten for each project as needed. For example, it
+might make sense to disable the Rails rules for gems:
+
+```yaml
+Rails:
+  Enabled: false
+```
+
+## Releases
+
+This gem does **not** follow [SemVer](https://semver.org), since any change to
+the style guide must be considered a breaking change. When making any changes to
+the style guide, increase the version number in the `gemspec`.  
+
+Document all changes in the `CHANGELOG`, so that it is easy to check if specific
+rules need to be overwritten in a projec.t When changes to the guide are merged
+into `master`, create a new release on GitHub and tag it with the new version
+number.
+
+## License
+
+The gem is available as open source under the terms of the
+[MIT License](https://opensource.org/licenses/MIT).
+
+[inspire]: https://inspire.nl
+[rubocop]: https://github.com/rubocop-hq/rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/default.yml
+++ b/default.yml
@@ -1,0 +1,138 @@
+AllCops:
+  Exclude:
+    - bin/**/*
+    - db/**/*
+    - lib/generators/**/*
+    - node_modules/**/*
+    - vendor/ruby/**/*
+  TargetRubyVersion: 2.5
+
+Layout/AlignHash:
+  EnforcedLastArgumentHashStyle: ignore_implicit
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/ClassStructure:
+  Enabled: true
+  Categories:
+    module_inclusion:
+      - include
+      - prepend
+      - extend
+    scopes:
+      - default_scope
+      - scope
+    attributes:
+      - attr_accessor
+      - attr_reader
+      - attr_writer
+      - attribute
+    associations:
+      - belongs_to
+      - has_many
+      - has_one
+    validations:
+      - validates
+      - validate
+    hooks:
+      - after_commit
+      - after_create
+      - after_destroy
+      - after_rollback
+      - after_save
+      - after_update
+      - after_validation
+      - around_create
+      - around_destroy
+      - around_save
+      - around_update
+      - before_create
+      - before_destroy
+      - before_save
+      - before_update
+      - before_validation
+  ExpectedOrder:
+    - module_inclusion
+    - scopes
+    - constants
+    - attributes
+    - associations
+    - validations
+    - hooks
+    - public_class_methods
+    - initializer
+    - public_methods
+    - protected_methods
+    - private_methods
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 25
+  Exclude:
+    - spec/**/*
+
+Metrics/BlockLength:
+  Exclude:
+    - config/environments/*
+    - config/routes.rb
+    - lib/tasks/**/*
+    - spec/**/*
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/LineLength:
+  Enabled: true
+  Exclude:
+    - config/**/*
+  Max: 125
+
+Metrics/MethodLength:
+  Max: 25
+  Exclude:
+    - spec/**/*
+
+Naming/FileName:
+  Enabled: false
+
+Rails:
+  Enabled: true
+
+Rails/Validation:
+  Include:
+    - app/models/**/*.rb
+    - app/forms/**/*.rb
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/FormatString:
+  EnforcedStyle: sprintf
+
+Style/RegexpLiteral:
+  EnforcedStyle: mixed
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+
+Style/TrivialAccessors:
+  AllowPredicates: true
+  AllowDSLWriters: true

--- a/inspire-ruby-style.gemspec
+++ b/inspire-ruby-style.gemspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name     = "inspire-ruby-style"
+  spec.version  = "1.0.0"
+  spec.authors  = ["Inspire Innovation BV"]
+  spec.email    = ["info@inspire.nl"]
+
+  spec.summary  = "Inspire's shared style guides for Ruby."
+  spec.homepage = "https://github.com/InspireNL/inspire-ruby-style"
+  spec.license  = "MIT"
+
+  spec.files    = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+
+  spec.add_dependency "rubocop", "~> 0.58"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 10.0"
+end


### PR DESCRIPTION
Rubocop can inherit its configuration from a gem. This allows us to
distribute a global configuration for all projects that is inherited and
customized where needed.

For distribution, a new gem has been created. The gem contains only the
default configuration file, the gemspec and its documentation. Since the
gem doesn't implement any logic, no Ruby files are included.