### PR TITLE
Match file paths recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ but please note that the style guide does **not** follow [SemVer](https://semver
 
 -
 
+## [v3]
+
+### Changed
+
+- Prefix paths with a wildcard to match nested directories
+
 ## [v2]
 
 ### Added
@@ -39,6 +45,7 @@ but please note that the style guide does **not** follow [SemVer](https://semver
 
 - `Naming/MemoizedInstanceVariableName` (project-specific)
 
-[Unreleased]: https://github.com/InspireNL/inspire-ruby-style/compare/v1...HEAD
+[Unreleased]: https://github.com/InspireNL/inspire-ruby-style/compare/v3...HEAD
+[v3]: https://github.com/InspireNL/inspire-ruby-style/tree/v3
 [v2]: https://github.com/InspireNL/inspire-ruby-style/tree/v2
 [v1]: https://github.com/InspireNL/inspire-ruby-style/tree/v1

--- a/default.yml
+++ b/default.yml
@@ -2,11 +2,11 @@ require: rubocop-rspec
 
 AllCops:
   Exclude:
-    - bin/**/*
-    - db/**/*
-    - lib/generators/**/*
-    - node_modules/**/*
-    - vendor/ruby/**/*
+    - "**/bin/**/*"
+    - "**/db/**/*"
+    - "**/lib/generators/**/*"
+    - "**/node_modules/**/*"
+    - "**/vendor/ruby/**/*"
   TargetRubyVersion: 2.5
 
 Layout/AlignHash:
@@ -80,14 +80,14 @@ Layout/SpaceBeforeFirstArg:
 Metrics/AbcSize:
   Max: 25
   Exclude:
-    - spec/**/*
+    - "**/spec/**/*"
 
 Metrics/BlockLength:
   Exclude:
-    - config/environments/*
-    - config/routes.rb
-    - lib/tasks/**/*
-    - spec/**/*
+    - "**/config/environments/*"
+    - "**/config/routes.rb"
+    - "**/lib/tasks/**/*"
+    - "**/spec/**/*"
 
 Metrics/CyclomaticComplexity:
   Max: 10
@@ -95,13 +95,13 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Enabled: true
   Exclude:
-    - config/**/*
+    - "**/config/**/*"
   Max: 125
 
 Metrics/MethodLength:
   Max: 25
   Exclude:
-    - spec/**/*
+    - "**/spec/**/*"
 
 Naming/FileName:
   Enabled: false
@@ -111,8 +111,8 @@ Rails:
 
 Rails/Validation:
   Include:
-    - app/models/**/*.rb
-    - app/forms/**/*.rb
+    - "**/app/forms/**/*.rb"
+    - "**/app/models/**/*.rb"
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested


### PR DESCRIPTION
In some projects, we nest Rails engines or Ruby gems inside the project directory. By prefixing the file paths with wildcards, the rules defined in the configuration file are applied even in these nested directories. This change enables us to use the style gem in projects that nest engines or gems.