### PR TITLE
Disable AmbiguousBlockAssociation rule for specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ but please note that the style guide does **not** follow [SemVer](https://semver
 
 -
 
+## [v4]
+
+- Disable `Lint/AmbiguousBlockAssociation` for specs
+
 ## [v3]
 
 ### Changed
@@ -45,7 +49,8 @@ but please note that the style guide does **not** follow [SemVer](https://semver
 
 - `Naming/MemoizedInstanceVariableName` (project-specific)
 
-[Unreleased]: https://github.com/InspireNL/inspire-ruby-style/compare/v3...HEAD
+[Unreleased]: https://github.com/InspireNL/inspire-ruby-style/compare/v4...HEAD
+[v4]: https://github.com/InspireNL/inspire-ruby-style/tree/v4
 [v3]: https://github.com/InspireNL/inspire-ruby-style/tree/v3
 [v2]: https://github.com/InspireNL/inspire-ruby-style/tree/v2
 [v1]: https://github.com/InspireNL/inspire-ruby-style/tree/v1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ with the newer version.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "inspire-ruby-style", github: "inspirenl/inspire-ruby-style", tag: "v3"
+gem "inspire-ruby-style", github: "inspirenl/inspire-ruby-style", tag: "v4"
 ```
 
 And then execute:

--- a/default.yml
+++ b/default.yml
@@ -77,6 +77,12 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceBeforeFirstArg:
   Enabled: false
 
+# This cop is incompatible with RSpec's idiom to use blocks as arguments for
+# many methods. Read more: https://github.com/rubocop-hq/rubocop/issues/4222
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "**/spec/**/*"
+
 Metrics/AbcSize:
   Max: 25
   Exclude:

--- a/inspire-ruby-style.gemspec
+++ b/inspire-ruby-style.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name     = "inspire-ruby-style"
-  spec.version  = "3.0.0"
+  spec.version  = "4.0.0"
   spec.authors  = ["Inspire Innovation BV"]
   spec.email    = ["info@inspire.nl"]
 

--- a/spec/versions/changelog_version_spec.rb
+++ b/spec/versions/changelog_version_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "Changelog version" do
     false
   end
 
+  subject(:version) { most_recent_tag }
+
   let(:changelog) { Pathname.new(__dir__).join("..", "..", "CHANGELOG.md") }
 
   let(:most_recent_tag) do
@@ -18,8 +20,6 @@ RSpec.describe "Changelog version" do
       line.match(/\A## \[v([\d]+)\]/) { |tag| return tag[1] }
     end
   end
-
-  subject(:version) { most_recent_tag }
 
   it "matches the major version in the gemspec" do
     gem_version = Gem.loaded_specs["inspire-ruby-style"].version.version

--- a/spec/versions/readme_version_spec.rb
+++ b/spec/versions/readme_version_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe "README version" do
+  subject(:version) { most_recent_tag }
+
   let(:readme) { Pathname.new(__dir__).join("..", "..", "README.md") }
   let(:regex) { %r{gem "inspire-ruby-style", github: "inspirenl/inspire-ruby-style", tag: "v([\d]+)"} }
 
@@ -11,8 +13,6 @@ RSpec.describe "README version" do
       line.match(regex) { |tag| return tag[1] }
     end
   end
-
-  subject(:version) { most_recent_tag }
 
   it "matches the major version in the gemspec" do
     gem_version = Gem.loaded_specs["inspire-ruby-style"].version.version


### PR DESCRIPTION
RuboCop's Lint/AmbiguousBlockAssociation rule is incompatible with
RSpec's idiom to use blocks as arguments for most of its methods.
Following the suggestions in RuboCop's issue tracker, the rule has been
disabled for the spec directory.